### PR TITLE
Feature/schemify get properties parent filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Register the `Event` Schema ([#6](https://github.com/stevegrunwell/schemify/issues/6)).
 * Fixed recursive schema bug for media objects ([#8](https://github.com/stevegrunwell/schemify/issues/8)).
 * Update Composer dependencies used for development.
+* Call the filter `schemify_get_properties_{$schema}` for each of a schema's ancestors when `Schemify\Schemas\Thing\getProperties` is called.
 
 
 ## [0.1.0]

--- a/tests/PHPUnit/schemas/ThingTest.php
+++ b/tests/PHPUnit/schemas/ThingTest.php
@@ -176,6 +176,16 @@ class ThingTest extends Schemify\TestCase {
 		$this->assertEquals( $random, $instance->getSchema() );
 	}
 
+	public function testGetSchemaArray() {
+		$instance = Mockery::mock( __NAMESPACE__ . '\Thing' )->makePartial();
+
+		M::userFunction( 'Schemify\Core\strip_namespace', array(
+			'return' => 'Thing',
+		) );
+
+		$this->assertEquals( array( 'Thing' ), $instance->getSchemaArray() );
+	}
+
 	public function testBuild() {
 		$instance = Mockery::mock( __NAMESPACE__ . '\Thing' )
 			->shouldAllowMockingProtectedMethods()


### PR DESCRIPTION
Call the filter `schemify_get_properties_{$schema}` for each of a schema's ancestors when `Schemify\Schemas\{Schema}\getProperties` is called.

Use case: I wanted to add the post content to the `articleBody` property for the Article schema and any children like BlogPosting. Currently, if I add a `schemify_get_properties_Article` filter, it is not called from `BlogPosting\getProperties`.